### PR TITLE
fix: Grant write permissions to GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   scrape:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The 'stefanzweifel/git-auto-commit-action' was failing with a permission denied error (403) because the workflow did not have the necessary permissions to write to the repository.

This commit adds the `permissions: contents: write` block to the `scrape` job in the `.github/workflows/main.yml` file. This explicitly grants the action the rights to commit and push changes, which is required for its operation.